### PR TITLE
Reverse order of tweets

### DIFF
--- a/mastodon-bot.cljs
+++ b/mastodon-bot.cljs
@@ -128,7 +128,8 @@
 (defn post-items [last-post-time items]
   (doseq [{:keys [text media-links]} (->> items
                                           (remove #(blocked-content? (:text %)))
-                                          (filter #(> (:created-at %) last-post-time)))]
+                                          (filter #(> (:created-at %) last-post-time))
+                                          (reverse))] ;; reverse the items
     (if media-links
       (post-status-with-images text media-links)
       (when-not (:media-only? mastodon-config)


### PR DESCRIPTION
This PR should help maintain the chronological order of items when crossposting.

Context: https://github.com/yogthos/mastodon-bot/issues/27

